### PR TITLE
Added fetch for singular pictogram

### DIFF
--- a/__tests__/ActivityItem.test.tsx
+++ b/__tests__/ActivityItem.test.tsx
@@ -5,6 +5,7 @@ import usePictogram from "../hooks/usePictogram";
 
 
 jest.mock("../hooks/usePictogram");
+jest.useRealTimers();
 
 test("swiping left triggers deleteActivity", async () => {
   const deleteActivity = jest.fn();

--- a/__tests__/ActivityItem.test.tsx
+++ b/__tests__/ActivityItem.test.tsx
@@ -1,27 +1,41 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react-native";
 import ActivityItem from "../components/weekoverview_components/activity_components/ActivityItem";
+import usePictogram from "../hooks/usePictogram";
 
-test("swiping left triggers deleteActivity", () => {
+
+jest.mock("../hooks/usePictogram");
+
+test("swiping left triggers deleteActivity", async () => {
   const deleteActivity = jest.fn();
   const editActivity = jest.fn();
   const checkActivity = jest.fn();
   const showDetails = jest.fn();
 
-  render(
-    <ActivityItem
-      time="09:00-10:00"
-      label="Activity 1"
-      deleteActivity={deleteActivity}
-      editActivity={editActivity}
-      checkActivity={checkActivity}
-      isCompleted={false}
-      showDetails={showDetails}
-    />,
-  );
+  // Mocking useFetchPictograms return values
+  (usePictogram as jest.Mock).mockReturnValue({
+    useFetchPictograms: {
+      data: 'https://api.arasaac.org/v1/pictograms/27575?color=true&download=false', // Mock image URL
+      error: null,
+      isLoading: false,
+    },
+  });
 
+  render(
+      <ActivityItem
+          time="09:00-10:00"
+          label="Activity 1"
+          deleteActivity={deleteActivity}
+          editActivity={editActivity}
+          checkActivity={checkActivity}
+          isCompleted={false}
+          showDetails={showDetails}
+      />,
+  );
+  // Simulate the button press
   fireEvent.press(screen.getByTestId("deleteActivityItemButton"));
 
+  // Ensure deleteActivity is called
   expect(deleteActivity).toHaveBeenCalled();
 });
 
@@ -30,6 +44,14 @@ test("swiping right triggers editActivity and checkActivity", () => {
   const editActivity = jest.fn();
   const checkActivity = jest.fn();
   const showDetails = jest.fn();
+
+  (usePictogram as jest.Mock).mockReturnValue({
+    useFetchPictograms: {
+      data: 'https://api.arasaac.org/v1/pictograms/27575?color=true&download=false', // Mock image URL
+      error: null,
+      isLoading: false,
+    },
+  });
 
   render(
     <ActivityItem

--- a/apis/pictogramAPI.ts
+++ b/apis/pictogramAPI.ts
@@ -1,0 +1,13 @@
+export const fetchPictograms = async () => {
+    const res = await fetch(`https://api.arasaac.org/v1/pictograms/27575?color=true&download=false`);
+
+    if (!res.ok) throw new Error(`Failed to fetch pictograms, status code: ${res.status}`);
+
+    const contentType = res.headers.get('Content-Type');
+    if (contentType?.includes('image/png') || contentType?.includes('image/jpeg')) {
+        const imageBlob = await res.blob();
+        return URL.createObjectURL(imageBlob);
+    } else {
+        throw new Error('Response is not an image');
+    }
+};

--- a/apis/pictogramAPI.ts
+++ b/apis/pictogramAPI.ts
@@ -1,5 +1,5 @@
-export const fetchPictograms = async () => {
-    const res = await fetch(`https://api.arasaac.org/v1/pictograms/27575?color=true&download=false`);
+export const fetchPictograms = async (id: number) => {
+    const res = await fetch(`https://api.arasaac.org/v1/pictograms/${id}?color=true&download=false`);
 
     if (!res.ok) throw new Error(`Failed to fetch pictograms, status code: ${res.status}`);
 

--- a/components/weekoverview_components/activity_components/ActivityItem.tsx
+++ b/components/weekoverview_components/activity_components/ActivityItem.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Pressable,
+  Image,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import ReanimatedSwipeable, {
@@ -14,8 +15,9 @@ import Reanimated, {
   SharedValue,
   useAnimatedStyle,
 } from "react-native-reanimated";
+import usePictogram from "../../../hooks/usePictogram";
 
-const CONTAINER_HEIGHT = 80;
+const CONTAINER_HEIGHT = 140;
 const CONTAINER_PADDING = 12;
 const ACTION_WIDTH = 70;
 
@@ -95,6 +97,8 @@ const ActivityItem: React.FC<ActivityItemProps> = ({
   checkActivity,
   showDetails,
 }) => {
+  const { useFetchPictograms } = usePictogram();
+  const { data, error, isLoading } = useFetchPictograms;
   const swipeableRef = React.useRef<SwipeableMethods>(null);
 
   const handleCloseOnCheckTaskPress = () => {
@@ -113,6 +117,10 @@ const ActivityItem: React.FC<ActivityItemProps> = ({
 
     editActivity();
   };
+
+  if (!isLoading && error) {
+    throw new Error("Failed to fetch pictograms");
+  }
 
   return (
     <ReanimatedSwipeable
@@ -143,7 +151,15 @@ const ActivityItem: React.FC<ActivityItemProps> = ({
             {label}
           </Text>
           <View style={styles.iconContainer}>
-            <Text style={styles.iconPlaceholderText}>Photo</Text>
+            {data ? (
+                <Image
+                    source={{ uri: data }}
+                    style={{ width: 90, height: 90 }}
+                    resizeMode="contain"
+                />
+            ) : (
+                <Text style={styles.iconPlaceholderText}>No Icon</Text>
+            )}
           </View>
         </View>
       </Pressable>
@@ -173,8 +189,8 @@ const styles = StyleSheet.create({
     flex: 0.6,
   },
   iconContainer: {
-    width: 65,
-    height: 65,
+    width: 120,
+    height: 120,
     borderRadius: 100,
     backgroundColor: "#FFCC80",
     justifyContent: "center",

--- a/components/weekoverview_components/activity_components/ActivityItem.tsx
+++ b/components/weekoverview_components/activity_components/ActivityItem.tsx
@@ -97,7 +97,7 @@ const ActivityItem: React.FC<ActivityItemProps> = ({
   checkActivity,
   showDetails,
 }) => {
-  const { useFetchPictograms } = usePictogram();
+  const { useFetchPictograms } = usePictogram(27575);
   const { data, error, isLoading } = useFetchPictograms;
   const swipeableRef = React.useRef<SwipeableMethods>(null);
 

--- a/components/weekoverview_components/activity_components/ActivityItem.tsx
+++ b/components/weekoverview_components/activity_components/ActivityItem.tsx
@@ -123,47 +123,47 @@ const ActivityItem: React.FC<ActivityItemProps> = ({
   }
 
   return (
-    <ReanimatedSwipeable
-      ref={swipeableRef}
-      overshootFriction={10}
-      overshootLeft={false}
-      overshootRight={false}
-      renderLeftActions={(prog, drag) => LeftAction(prog, drag, deleteActivity)}
-      renderRightActions={(prog, drag) =>
-        RightAction(
-          prog,
-          drag,
-          handleCloseOnEditTaskPress,
-          handleCloseOnCheckTaskPress,
-        )
-      }
-      friction={2}
-    >
-      <Pressable onPress={showDetails}>
-        <View
-          style={[
-            styles.taskContainer,
-            { backgroundColor: isCompleted ? "#A5D6A7" : "#E3F2FD" },
-          ]}
-        >
-          <Text style={styles.timeText}>{time.replace("-", "\n")}</Text>
-          <Text style={styles.labelText} numberOfLines={2} ellipsizeMode="tail">
-            {label}
-          </Text>
-          <View style={styles.iconContainer}>
-            {data ? (
-                <Image
-                    source={{ uri: data }}
-                    style={{ width: 90, height: 90 }}
-                    resizeMode="contain"
-                />
-            ) : (
-                <Text style={styles.iconPlaceholderText}>No Icon</Text>
-            )}
+      <ReanimatedSwipeable
+          ref={swipeableRef}
+          overshootFriction={10}
+          overshootLeft={false}
+          overshootRight={false}
+          renderLeftActions={(prog, drag) => LeftAction(prog, drag, deleteActivity)}
+          renderRightActions={(prog, drag) =>
+              RightAction(
+                  prog,
+                  drag,
+                  handleCloseOnEditTaskPress,
+                  handleCloseOnCheckTaskPress,
+              )
+          }
+          friction={2}
+      >
+        <Pressable onPress={showDetails}>
+          <View
+              style={[
+                styles.taskContainer,
+                { backgroundColor: isCompleted ? "#A5D6A7" : "#E3F2FD" },
+              ]}
+          >
+            <Text style={styles.timeText}>{time.replace("-", "\n")}</Text>
+            <Text style={styles.labelText} numberOfLines={2} ellipsizeMode="tail">
+              {label}
+            </Text>
+            <View style={styles.iconContainer}>
+              {data ? (
+                  <Image
+                      source={{ uri: data }}
+                      style={{ width: 90, height: 90 }}
+                      resizeMode="contain"
+                  />
+              ) : (
+                  <Text style={styles.iconPlaceholderText}>No Icon</Text>
+              )}
+            </View>
           </View>
-        </View>
-      </Pressable>
-    </ReanimatedSwipeable>
+        </Pressable>
+      </ReanimatedSwipeable>
   );
 };
 
@@ -202,7 +202,7 @@ const styles = StyleSheet.create({
   },
   action: {
     width: ACTION_WIDTH,
-    height: 80,
+    height: 140,
     backgroundColor: "crimson",
     justifyContent: "center",
     alignItems: "center",

--- a/hooks/usePictogram.ts
+++ b/hooks/usePictogram.ts
@@ -1,8 +1,8 @@
 import {useQuery} from "@tanstack/react-query";
 import {fetchPictograms} from "../apis/pictogramAPI";
 
-export default function usePictogram() {
-    const queryKey = ['pictograms'];
+export default function usePictogram(id: number) {
+    const queryKey = ['pictograms', id];
 
     const useFetchPictograms = useQuery({
         queryFn: async () => fetchPictograms(27575),

--- a/hooks/usePictogram.ts
+++ b/hooks/usePictogram.ts
@@ -5,7 +5,7 @@ export default function usePictogram() {
     const queryKey = ['pictograms'];
 
     const useFetchPictograms = useQuery({
-        queryFn: fetchPictograms,
+        queryFn: async () => fetchPictograms(27575),
         queryKey: queryKey,
     });
 

--- a/hooks/usePictogram.ts
+++ b/hooks/usePictogram.ts
@@ -1,0 +1,15 @@
+import {useQuery} from "@tanstack/react-query";
+import {fetchPictograms} from "../apis/pictogramAPI";
+
+export default function usePictogram() {
+    const queryKey = ['pictograms'];
+
+    const useFetchPictograms = useQuery({
+        queryFn: fetchPictograms,
+        queryKey: queryKey,
+    });
+
+    return {
+        useFetchPictograms,
+    };
+}


### PR DESCRIPTION
Added fetch functionality for a single pictogram based on an ID. Styling has also been slightly altered to fit with the pictogram such that it is more visible on the Ipad. DISCLAIMER: This is only for demonstration purposes for the thursday meeting, it is by no means a final product and is only there to showcase what our initial design sketches would look like with a pictogram. 

## Description

Please include a summary of the changes and the related issue/ticket from our GitHub Projects.

## Type of PR

<!-- Select one type by removing the others -->

- Bugfix
- Feature
- Code style update
- Refactor
- Documentation update
- Other (please describe):

## Related Issues/Tickets

Please link the related issues/tickets here.

## Checklist

- [ ] Code follows the code guidelines
