### PR TITLE
Change Camera.test.tsx so it doesnt have any coding errors

### DIFF
--- a/__tests__/Camera.test.tsx
+++ b/__tests__/Camera.test.tsx
@@ -1,11 +1,10 @@
 import { takePhoto } from "../components/Camera/Camera";
-import * as ImagePicker from 'expo-image-picker';
+import * as ImagePicker from "expo-image-picker";
 
-// Mock the expo-image-picker library to control its behavior in tests
-jest.mock('expo-image-picker', () => ({
+jest.mock("expo-image-picker", () => ({
   requestCameraPermissionsAsync: jest.fn(),
   launchCameraAsync: jest.fn(),
-  MediaTypeOptions: { Images: 'Images' }
+  MediaTypeOptions: { Images: "Images" },
 }));
 
 describe("takePhoto", () => {
@@ -14,7 +13,9 @@ describe("takePhoto", () => {
   });
 
   it("should request camera permissions", async () => {
-    ImagePicker.requestCameraPermissionsAsync.mockResolvedValue({ granted: true });
+    (ImagePicker.requestCameraPermissionsAsync as jest.Mock).mockResolvedValue({
+      granted: true,
+    });
 
     await takePhoto();
 
@@ -22,25 +23,33 @@ describe("takePhoto", () => {
   });
 
   it("should alert if permission is denied", async () => {
-    ImagePicker.requestCameraPermissionsAsync.mockResolvedValue({ granted: false });
+    (ImagePicker.requestCameraPermissionsAsync as jest.Mock).mockResolvedValue({
+      granted: false,
+    });
     global.alert = jest.fn();
     await takePhoto();
 
-    expect(global.alert).toHaveBeenCalledWith("Camera access is required to take a photo!");
+    expect(global.alert).toHaveBeenCalledWith(
+      "Camera access is required to take a photo!"
+    );
   });
 
   it("should launch camera if permission is granted", async () => {
-    ImagePicker.requestCameraPermissionsAsync.mockResolvedValue({ granted: true });
+    (ImagePicker.requestCameraPermissionsAsync as jest.Mock).mockResolvedValue({
+      granted: true,
+    });
 
     const mockCameraResult = {
       canceled: false,
-      assets: [{ uri: 'mockImageUri' }],
+      assets: [{ uri: "mockImageUri" }],
     };
-    ImagePicker.launchCameraAsync.mockResolvedValue(mockCameraResult);
+    (ImagePicker.launchCameraAsync as jest.Mock).mockResolvedValue(
+      mockCameraResult
+    );
 
     const uri = await takePhoto();
 
     expect(ImagePicker.launchCameraAsync).toHaveBeenCalled();
-    expect(uri).toBe('mockImageUri');
+    expect(uri).toBe("mockImageUri");
   });
 });

--- a/components/Camera/Camera.tsx
+++ b/components/Camera/Camera.tsx
@@ -1,15 +1,12 @@
-import * as ImagePicker from 'expo-image-picker';
+import * as ImagePicker from "expo-image-picker";
 
 export const takePhoto = async () => {
   const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
 
-  // Check if permission is granted
-  if (permissionResult.granted === false) {
+  if (!permissionResult.granted) {
     alert("Camera access is required to take a photo!");
     return null;
   }
-
-  // Launch the camera to take a photo
   const result = await ImagePicker.launchCameraAsync({
     mediaTypes: ImagePicker.MediaTypeOptions.Images,
     allowsEditing: false,
@@ -19,4 +16,3 @@ export const takePhoto = async () => {
 
   return result && !result.canceled ? result.assets[0].uri : null;
 };
-


### PR DESCRIPTION
## Description

Updated Camera.test.tsx as it had this to errors:
TS2339: Property mockResolvedValue does not exist on type () => Promise<PermissionResponse>

TS2339: Property mockResolvedValue does not exist on type
(options?: ImagePickerOptions | undefined) => Promise<ImagePickerResult> 

Have been solved by mocking ImagePicker.requestCameraPermissionsAsync

## Type of PR

- Bugfix
## Related Issues/Tickets

Please link the related issues/tickets here.

## Checklist

- [] Completed the user story described by the issue (if applicable)
- [x] Code follows the code guidelines
- [x] Tests have been added/updated (if applicable)
- [] Documentation has been updated (if applicable)
