### PR TITLE
Delete routing fix

### DIFF
--- a/app/auth/profile/organisation/grade/settings.tsx
+++ b/app/auth/profile/organisation/grade/settings.tsx
@@ -94,7 +94,7 @@ const Settings = () => {
         addToast({ message: error.message, type: "error" });
       });
     deleteCloseBS();
-    router.push(`/auth/profile/organisation/${data?.id}`);
+    router.dismissTo(`/auth/profile/organisation/${data?.id}`);
   };
 
   type deleteBottomSheetProps = {

--- a/app/auth/profile/organisation/settings.tsx
+++ b/app/auth/profile/organisation/settings.tsx
@@ -156,7 +156,7 @@ const Settings = () => {
         addToast({ message: error.message, type: "error" });
       });
     deleteCloseBS();
-    router.push("/auth/profile/profilepage");
+    router.dismissTo("/auth/profile/profilepage");
   };
 
   type deleteBottomSheetProps = {


### PR DESCRIPTION
## Description

Change routing for delete Org and delete Grade to dismissTo, to ensure you cant go back to deleted Org/Grades

## Type of PR

- Bugfix

## Checklist

- [X] Completed the user story described by the issue (if applicable)
- [X] Code follows the code guidelines
